### PR TITLE
Log to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Gemfile* ./
 RUN bundle install
 
 FROM ruby:2.7.1
-ENV RAILS_ENV=development
+ENV RAILS_ENV=development, RAILS_LOG_TO_STDOUT=ON
 WORKDIR /app
 RUN apt-get update && apt-get install -y curl
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
Fixes https://github.com/jacopen/cndtattend/issues/9

ログ出力のハンドリングはここでやっている
https://github.com/jacopen/cndtattend/blob/master/config/environments/production.rb#L83

つまり、`RAILS_LOG_TO_STDOUT`の環境変数が存在すれば出力が切り替わる